### PR TITLE
Make dependency flags manual

### DIFF
--- a/invertible.cabal
+++ b/invertible.cabal
@@ -24,20 +24,36 @@ source-repository head
 
 flag arrows
   description: Support the arrows package
+  manual: True
+  default: True
 flag HList
   description: Support the HList package
+  manual: True
+  default: True
 flag invariant
   description: Support the invariant package
+  manual: True
+  default: True
 flag lens
   description: Support the lens package
+  manual: True
+  default: True
 flag partial-isomorphisms
   description: Support the partial-isomorphisms package
+  manual: True
+  default: True
 flag Piso
   description: Support the Piso package
+  manual: True
+  default: True
 flag semigroupoids
   description: Support the semigroupoids package
+  manual: True
+  default: True
 flag TypeCompose
   description: Support the TypeCompose package
+  manual: True
+  default: True
 
 library
   other-modules:


### PR DESCRIPTION
This causes all modules to be compiled unless explicitly disabled.

Manual flags should be used for toggling features and default to enabled, otherwise a dependency on this library could fail to compile because a feature was disabled implicitly. You can't depend on a package with certain flags, and you can't have two versions of the same package in use at the same time.

Another solution is to split the features into separate packages.

This also caused some packages to be excluded from LTS 8: fpco/stackage#2305